### PR TITLE
Feat/vehicle types table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project needs the rust tooling, including cargo.
 The diesel cli is needed, you can install it with the following command.
 
 ```sh
+sudo apt install libmysqlclient-dev  # MySQL deps
 cargo install diesel_cli --no-default-features --features mysql
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ There are types for a complete record, a new one or an updating one.
 `diesel` feature enables *derive* attributes on models for querying. It also enables the `schema` module for compile time query validation.  
 Finally, this enables a `migrations` module which embed the migrations for later run.
 
+## Tools
+
+This project needs the rust tooling, including cargo.  
+The diesel cli is needed, you can install it with the following command.
+
+```sh
+cargo install diesel_cli --no-default-features --features mysql
+```
+
+This project also needs a **MySQL** database, the easiest way to have one is with docker.
+
 ## Contributing
 
 1. Run `diesel migration generate create_<table>` to create the migrations
@@ -23,5 +34,13 @@ Finally, this enables a `migrations` module which embed the migrations for later
 5. This *struct* derives from `Debug`, `Clone`, 'Serialize' & `Deserialize`
 6. With *diesel* feature, it derives from `Queryable`. You can also specify the table name if needed
 7. The model file should also contains `struct` for a new model and an updating model
+
+
+You can quickly setup a database and run the migration with the following commands. This is actually required to generate the schema file.
+
+```sh
+docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=provoit -d -p 3306:3306 --rm mysql:latest
+diesel migration run --database-url mysql://root:root@127.0.0.1/provoit
+```
 
 Take example on other models.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sudo apt install libmysqlclient-dev  # MySQL deps
 cargo install diesel_cli --no-default-features --features mysql
 ```
 
-This project also needs a **MySQL** database, the easiest way to have one is with docker.
+This project also needs a **MySQL** database, the easiest way is using docker.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Finally, this enables a `migrations` module which embed the migrations for later
 ## Tools
 
 This project needs the rust tooling, including cargo.  
-The diesel cli is needed, you can install it with the following command.
+The diesel CLI is needed, you can install it with the following command.
 
 ```sh
 sudo apt install libmysqlclient-dev  # MySQL deps

--- a/migrations/2023-05-22-061038_create_vehicle_types/down.sql
+++ b/migrations/2023-05-22-061038_create_vehicle_types/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE IF EXISTS vehicle_types;

--- a/migrations/2023-05-22-061038_create_vehicle_types/up.sql
+++ b/migrations/2023-05-22-061038_create_vehicle_types/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+
+CREATE TABLE `vehicle_types` (
+  `id` bigint unsigned PRIMARY KEY AUTO_INCREMENT,
+  `label` text NOT NULl
+);

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,2 +1,3 @@
 /// This module contains all the application models
 pub mod user;
+pub mod vehicle_types;

--- a/src/models/vehicle_types.rs
+++ b/src/models/vehicle_types.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "diesel")]
+use diesel::prelude::*;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "diesel", derive(Queryable))]
+#[cfg_attr(feature = "diesel", diesel(table_name = vehicle_types))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VehicleType {
+    id: u64,
+    label: String,
+}
+
+// `vehicle_types` is an enumeration table, is shouldn't need to be updated or created via model.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -14,7 +14,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    users,
-    vehicle_types,
-);
+diesel::allow_tables_to_appear_in_same_query!(users, vehicle_types,);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,3 +6,15 @@ diesel::table! {
         name -> Text,
     }
 }
+
+diesel::table! {
+    vehicle_types (id) {
+        id -> Unsigned<Bigint>,
+        label -> Text,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    users,
+    vehicle_types,
+);


### PR DESCRIPTION
# Description

This PR adds the `vehicle_types` migrations and models.

I also documented a bit more the process of creating a new table and the tools required.