### PR TITLE
refactor: making attributes public

### DIFF
--- a/src/models/days.rs
+++ b/src/models/days.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "diesel", diesel(table_name = days))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Day {
-    id: u64,
-    label: String,
+    pub id: u64,
+    pub label: String,
 }
 
 // `days` is an enumeration table, is shouldn't need to be updated or created via model.

--- a/src/models/frequencies.rs
+++ b/src/models/frequencies.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "diesel", diesel(table_name = frequencies))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Frequency {
-    id: u64,
-    label: String,
+    pub id: u64,
+    pub label: String,
 }
 
 // `frequencies` is an enumeration table, is shouldn't need to be updated or created via model.

--- a/src/models/road_types.rs
+++ b/src/models/road_types.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "diesel", diesel(table_name = road_types))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoadType {
-    id: u64,
-    label: String,
+    pub id: u64,
+    pub label: String,
 }
 
 // `road_types` is an enumeration table, is shouldn't need to be updated or created via model.

--- a/src/models/vehicle_types.rs
+++ b/src/models/vehicle_types.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "diesel", diesel(table_name = vehicle_types))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VehicleType {
-    id: u64,
-    label: String,
+    pub id: u64,
+    pub label: String,
 }
 
 // `vehicle_types` is an enumeration table, is shouldn't need to be updated or created via model.


### PR DESCRIPTION
# Description

Attributes actually need to be public to be accessed.

Even the password is public, I don't think this is a problem, this is just regular behavior either for js or php.