### PR TITLE
feat: From trait for NewVehicle

### DIFF
--- a/migrations/2023-05-22-061038_create_vehicle_types/up.sql
+++ b/migrations/2023-05-22-061038_create_vehicle_types/up.sql
@@ -4,3 +4,11 @@ CREATE TABLE `vehicle_types` (
   `id` bigint unsigned PRIMARY KEY AUTO_INCREMENT,
   `label` text NOT NULl
 );
+
+INSERT INTO `vehicle_types`(`id`, `label`)
+VALUES
+(1, "Berline"),
+(2, "Citadine"),
+(3, "Utilitaire"),
+(4, "Franchisseur"),
+(5, "SUV");

--- a/migrations/2023-05-22-061038_create_vehicle_types/up.sql
+++ b/migrations/2023-05-22-061038_create_vehicle_types/up.sql
@@ -11,4 +11,9 @@ VALUES
 (2, "Citadine"),
 (3, "Utilitaire"),
 (4, "Franchisseur"),
-(5, "SUV");
+(5, "SUV"),
+(6, "Coupé"),
+(7, "Cabriolet"),
+(8, "Break"),
+(9, "Pickup");
+

--- a/src/models/vehicles.rs
+++ b/src/models/vehicles.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+use std::collections::HashMap;
+
 #[cfg(feature = "diesel")]
 use diesel::prelude::*;
 
@@ -35,6 +37,38 @@ pub struct NewVehicle {
     pub pic: Option<Vec<u8>>,
     pub id_user: Option<u64>,
     pub id_type: u64,
+}
+
+/// Convert to a NewVehicle from an event's HashMap
+impl From<HashMap<String, String>> for NewVehicle {
+    fn from(value: HashMap<String, String>) -> Self {
+        Self {
+            name: value.get("name").expect("Le nom est requis").to_owned(),
+            year: value
+                .get("year")
+                .expect("Année requise")
+                .parse()
+                .expect("Année invalide"),
+            nb_doors: value
+                .get("nb_doors")
+                .expect("Le nombre de porte est requis")
+                .parse()
+                .expect("Nombre de portes invalide"),
+            nb_seats: value
+                .get("nb_seats")
+                .expect("Le nombre de sièges est requis")
+                .parse()
+                .expect("Nombre de sièges invalide"),
+            trunk_size_L: value
+                .get("trunk_size_L")
+                .expect("La taille du coffre est requise")
+                .parse()
+                .expect("Taille du coffre incorrecte"),
+            pic: None,
+            id_user: None,
+            id_type: 1,
+        }
+    }
 }
 
 #[cfg_attr(feature = "diesel", derive(AsChangeset))]

--- a/src/models/vehicles.rs
+++ b/src/models/vehicles.rs
@@ -66,7 +66,11 @@ impl From<HashMap<String, String>> for NewVehicle {
                 .expect("Taille du coffre incorrecte"),
             pic: None,
             id_user: None,
-            id_type: 1,
+            id_type: value
+                .get("vehicle_type")
+                .expect("Le type de véhicule est requis")
+                .parse()
+                .expect("Type de véhicule invalide"),
         }
     }
 }


### PR DESCRIPTION
I added the `From` trait for `NewVehicle`. This enables us to to do `event.values.into()` directly from an event's values.